### PR TITLE
fix: missing input resulting in build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
+          distribution: 'temurin'
           
       - id: get-project
         name: Get Project Name


### PR DESCRIPTION
when run by github actions, it fails right about on the 'Set Up JDK' step